### PR TITLE
add simple setup.py for installation

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,10 @@
+from setuptools import setup, find_packages
+setup(
+    name="DarkElf",
+    version="1.1",
+    package_dir = {"darkelf":"darkelf"},
+    packages=find_packages(),
+    author='Brian Campbell-Deem, Simon Knapen, Jonathan Kozaczuk, Tongyan Lin, Connor Stratman, and Ethan Villarama',
+    description="package capable of calculating interaction rates of light dark matter in dielectric materials, including screening effects",
+
+)


### PR DESCRIPTION
By adding a nominal setup.py, the DarkELF package can be loaded by other software more easily; 

```
  cd DarkELF
  pip install -e . --user #installs DarkELF as a python package
  cd  #moves out of the DarkELF folder 
  ipython 
    In [1] : from darkelf.epsilon import load_epsilon_grid
``` 